### PR TITLE
Fix typo in selector prefixing

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,7 +23,7 @@
   ga('send', 'pageview');
 </script>
 <!-- End Google Analytics -->
-<script>
-      $(#sessionStorage.getItem('cat')).addClass("active");
-</script>
+<script>$(function(){
+      $('#' + sessionStorage.getItem('cat')).addClass("active");
+})</script>
 </head>


### PR DESCRIPTION
Also, run `addClass` on `.ready` time.